### PR TITLE
fix: add loader for monaco editor to work offline

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,37 @@ import { closeSnackbar, SnackbarProvider } from 'notistack';
 import { queryClient } from './api/tanstack/queryClient';
 import { IconButton } from '@mui/material';
 import { HighlightOff } from '@mui/icons-material';
+import { loader } from '@monaco-editor/react';
+import * as monaco from 'monaco-editor';
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
+import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker';
+import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker';
+import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
+
+self.MonacoEnvironment = {
+  getWorker(_, label) {
+    if (label === 'json') {
+      return new jsonWorker();
+    }
+    if (label === 'css' || label === 'scss' || label === 'less') {
+      return new cssWorker();
+    }
+    if (label === 'html' || label === 'handlebars' || label === 'razor') {
+      return new htmlWorker();
+    }
+    if (label === 'typescript' || label === 'javascript') {
+      return new tsWorker();
+    }
+    return new editorWorker();
+  },
+};
+
+loader.config({ monaco });
+
+loader.init().then(() => {
+  console.log('initialized monaco loaders');
+});
 
 function App() {
   return (


### PR DESCRIPTION
This pull request introduces the integration of the Monaco Editor into the `src/App.tsx` file. The changes include importing necessary workers and configuring the Monaco environment for deployment in an airgapped environment.

Key changes include:

* Added imports for `loader` from `@monaco-editor/react` and various Monaco Editor workers.
* Defined the `MonacoEnvironment` to specify different workers for handling JSON, CSS, HTML, and TypeScript/JavaScript files.
* Configured and initialized the Monaco loader, logging a message upon successful initialization.