### PR TITLE
feat: extend validator keywords to include 'x-env-format'

### DIFF
--- a/src/pages/config/viewConfig/viewConfig.tsx
+++ b/src/pages/config/viewConfig/viewConfig.tsx
@@ -9,7 +9,7 @@ import { useQuery } from '@tanstack/react-query';
 import Styles from './viewConfig.module.scss';
 import { QueryDataRenderer } from '../../../components/queryDataRenderer/queryDataRenderer';
 
-const validator = customizeValidator({ ajvOptionsOverrides: { discriminator: true, keywords: ['x-env-value'] }, AjvClass: Ajv2019 });
+const validator = customizeValidator({ ajvOptionsOverrides: { discriminator: true, keywords: ['x-env-value', 'x-env-format'] }, AjvClass: Ajv2019 });
 
 validator.ajv.addMetaSchema(draft7MetaSchema);
 

--- a/src/utils/ajv.ts
+++ b/src/utils/ajv.ts
@@ -5,7 +5,7 @@ import { getSchema } from '../api/client';
 import { ErrorMessages } from './errors/error.types';
 
 export const ajvInstance = new ajv({
-  keywords: ['x-env-value'],
+  keywords: ['x-env-value', 'x-env-format'],
   useDefaults: true,
   discriminator: true,
   loadSchema: async (uri): Promise<AnySchemaObject> => {


### PR DESCRIPTION
Added support so ajv allowed the x-env-format keyword

related pull requests:
https://github.com/MapColonies/config-server/pull/85
https://github.com/MapColonies/config/pull/59
https://github.com/MapColonies/schemas/pull/82